### PR TITLE
Match Dockerfile.*

### DIFF
--- a/Dockerfile.plist
+++ b/Dockerfile.plist
@@ -300,6 +300,7 @@
 	<key>BBLMFileNamesToMatch</key>
 	<array>
 		<string>Dockerfile</string>
+		<string>Dockerfile.*</string>
 	</array>
 	<key>BBLMCommentLineDefault</key>
 	<string>#</string>


### PR DESCRIPTION
I was using a different implementation on a previous machine, but decided this one is more comprehensive. The only thing it's missing that the other implementation had was support for non-default Dockerfiles, using the syntax `Dockerfile.*`

You can see this naming convention in a lot of the projects for official repos, e.g https://github.com/AdoptOpenJDK/openjdk-docker/tree/master/11/jdk/ubuntu

